### PR TITLE
Add ability to listen for value changes

### DIFF
--- a/UtilityDelta.Gpio.Test/GpioPinTests.cs
+++ b/UtilityDelta.Gpio.Test/GpioPinTests.cs
@@ -137,5 +137,27 @@ namespace UtilityDelta.Gpio.Test
             fileIo.Verify(x => x.WriteAllText("/sys/class/gpio/gpio33/value", "0"), Times.Exactly(1));
             fileIo.Verify(x => x.ReadAllText(It.IsAny<string>()), Times.Never);
         }
+
+        [Fact]
+        public void TestGetValuePath()
+        {
+            var fileIo = new Mock<IFileIo>();
+            var pinMapper = new Mock<IPinMapper>();
+            pinMapper.Setup(x => x.MapPinToSysfs("21")).Returns(33);
+            var service = new PinController(fileIo.Object, pinMapper.Object);
+            var pin = service.GetGpioPin("21");
+            Assert.Equal("/sys/class/gpio/gpio33/value", pin.GetValuePath());
+        }
+
+        [Fact]
+        public void TestGetDirectionPath()
+        {
+            var fileIo = new Mock<IFileIo>();
+            var pinMapper = new Mock<IPinMapper>();
+            pinMapper.Setup(x => x.MapPinToSysfs("21")).Returns(33);
+            var service = new PinController(fileIo.Object, pinMapper.Object);
+            var pin = service.GetGpioPin("21");
+            Assert.Equal("/sys/class/gpio/gpio33/direction", pin.GetDirectionPath());
+        }
     }
 }

--- a/UtilityDelta.Gpio/EventArgs/PinChangedEventArgs.cs
+++ b/UtilityDelta.Gpio/EventArgs/PinChangedEventArgs.cs
@@ -1,0 +1,12 @@
+﻿namespace UtilityDelta.Gpio.EventArgs
+{
+    public class PinChangedEventArgs
+    {
+        public bool Value { get; }
+
+        public PinChangedEventArgs(bool value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/UtilityDelta.Gpio/Implementation/GpioPin.cs
+++ b/UtilityDelta.Gpio/Implementation/GpioPin.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using UtilityDelta.Gpio.Enums;
+using UtilityDelta.Gpio.EventArgs;
 using UtilityDelta.Gpio.Interfaces;
 
 namespace UtilityDelta.Gpio.Implementation
@@ -54,6 +55,10 @@ namespace UtilityDelta.Gpio.Implementation
                 _fileIo.WriteAllText(_valuePinPath, value ? PinOn : PinOff);
             }
         }
+
+        public string GetValuePath() => _valuePinPath;
+
+        public string GetDirectionPath() => _directionPinPath;
 
         private void SetDirection(GpioDirection gpioDirection)
         {

--- a/UtilityDelta.Gpio/Implementation/PinChangeReader.cs
+++ b/UtilityDelta.Gpio/Implementation/PinChangeReader.cs
@@ -56,6 +56,8 @@ namespace UtilityDelta.Gpio.Implementation
         public void Dispose()
         {
             Stop();
+            _valueChangedFileSystemWatcher.Dispose();
+            _directionChangedFileSystemWatcher.Dispose();
         }
     }
 }

--- a/UtilityDelta.Gpio/Implementation/PinChangeReader.cs
+++ b/UtilityDelta.Gpio/Implementation/PinChangeReader.cs
@@ -36,7 +36,8 @@ namespace UtilityDelta.Gpio.Implementation
 
         private void Watch(FileSystemWatcher fileSystemWatcher, string filePath)
         {
-            fileSystemWatcher.Path = filePath;
+            fileSystemWatcher.Path = Path.GetDirectoryName(filePath);
+            fileSystemWatcher.Filter = Path.GetFileName(filePath);
             fileSystemWatcher.Changed += OnGpioValueChanged;
             fileSystemWatcher.EnableRaisingEvents = true;
         }
@@ -45,6 +46,7 @@ namespace UtilityDelta.Gpio.Implementation
         {
             fileSystemWatcher.EnableRaisingEvents = false;
             fileSystemWatcher.Changed -= OnGpioValueChanged;
+            fileSystemWatcher.Filter = null;
             fileSystemWatcher.Path = null;
         }
 

--- a/UtilityDelta.Gpio/Implementation/PinChangeReader.cs
+++ b/UtilityDelta.Gpio/Implementation/PinChangeReader.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO;
+using UtilityDelta.Gpio.EventArgs;
+using UtilityDelta.Gpio.Interfaces;
+
+namespace UtilityDelta.Gpio.Implementation
+{
+    public class PinChangeReader : IPinChangeReader, IDisposable
+    {
+        private FileSystemWatcher _valueChangedFileSystemWatcher;
+        private FileSystemWatcher _directionChangedFileSystemWatcher;
+        private IGpioPin _pin;
+
+        public event EventHandler<PinChangedEventArgs> GpioChanged;
+
+        public PinChangeReader()
+        {
+            _valueChangedFileSystemWatcher = new FileSystemWatcher();
+            _directionChangedFileSystemWatcher = new FileSystemWatcher();
+        }
+
+        public void Start(IGpioPin pin)
+        {
+            _pin = pin ?? throw new Exception("Change reader needs to be supplied a GPIO pin");
+
+            Watch(_valueChangedFileSystemWatcher, _pin.GetValuePath());
+            Watch(_directionChangedFileSystemWatcher, _pin.GetDirectionPath());
+        }
+
+        public void Stop()
+        {
+            Unwatch(_valueChangedFileSystemWatcher);
+            Unwatch(_directionChangedFileSystemWatcher);
+            _pin = null;
+        }
+
+        private void Watch(FileSystemWatcher fileSystemWatcher, string filePath)
+        {
+            fileSystemWatcher.Path = filePath;
+            fileSystemWatcher.Changed += OnGpioValueChanged;
+            fileSystemWatcher.EnableRaisingEvents = true;
+        }
+
+        private void Unwatch(FileSystemWatcher fileSystemWatcher)
+        {
+            fileSystemWatcher.EnableRaisingEvents = false;
+            fileSystemWatcher.Changed -= OnGpioValueChanged;
+            fileSystemWatcher.Path = null;
+        }
+
+        private void OnGpioValueChanged(object sender, FileSystemEventArgs eventArgs)
+        {
+            GpioChanged?.Invoke(this, new PinChangedEventArgs(_pin.PinValue));
+        }
+
+        public void Dispose()
+        {
+            Stop();
+        }
+    }
+}

--- a/UtilityDelta.Gpio/Interfaces/IGpioPin.cs
+++ b/UtilityDelta.Gpio/Interfaces/IGpioPin.cs
@@ -7,5 +7,8 @@
         /// the pin direction ('out' - eg. controlling motors; and 'in' - eg. reading a digital sensor value)
         /// </summary>
         bool PinValue { get; set; }
+
+        string GetValuePath();
+        string GetDirectionPath();
     }
 }

--- a/UtilityDelta.Gpio/Interfaces/IPinChangeReader.cs
+++ b/UtilityDelta.Gpio/Interfaces/IPinChangeReader.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using UtilityDelta.Gpio.EventArgs;
+
+namespace UtilityDelta.Gpio.Interfaces
+{
+    internal interface IPinChangeReader
+    {
+        event EventHandler<PinChangedEventArgs> GpioChanged;
+        void Start(IGpioPin pin);
+        void Stop();
+    }
+}


### PR DESCRIPTION
It'd be really great to have something that fired an event when the GPIO pin's value changed, then things could subscribe to that event. UWP apps can make use of `Windows.Devices.Gpio.GpioChangeReader` that presumably does just this. This is useful when you need to respond to a button press or something similar.

Currently when using this repo you'd need to have a loop that continuously checked for GPIO pin value changes. I figured this would be wildly inefficient. I'm quite new to this sort of programming so forgive me if I'm doing something silly here!